### PR TITLE
Fixing null check on milestones

### DIFF
--- a/lib/issues/IssueHandler.js
+++ b/lib/issues/IssueHandler.js
@@ -78,15 +78,15 @@ class IssueHandler {
 
     if (Util.isNotUndefined(milestoneConfig)) {
       if (
-        Util.isNotUndefined(milestoneConfig.required_milestone_name) &&
         Util.isNotUndefined(milestoneConfig.message) &&
+        Util.isNotUndefined(milestoneConfig.required_milestone_name) &&
         Util.isNotUndefined(currentIssueMilestone) &&
         currentIssueMilestone.title != milestoneConfig.required_milestone_name
       ) {
         this.appendStatusMessage(
           `Only issues pertaining to the "${milestoneConfig.required_milestone_name}" milestone are acceptable!`
         )
-      } else if (Util.isUndefined(currentIssueMilestone)) {
+      } else if (Util.isNotUndefined(currentIssueMilestone)) {
         this.appendStatusMessage(milestoneConfig.message)
       }
     }


### PR DESCRIPTION
Reversed logic for checking nulls, causing status to post null messages incorrectly to issues that failed the analysis. 